### PR TITLE
Fixed: Automically updates average grade locally.

### DIFF
--- a/jefferson-elementary/package-lock.json
+++ b/jefferson-elementary/package-lock.json
@@ -3150,7 +3150,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.1.0.tgz",
       "integrity": "sha512-09o/rQHPZGEi658IXAJtWfra1N69D1eFnuJ3FQm9qUVzlzNnos1+GWgGiUeSs22QOpNm32aoVFOimq0p3Ug9Eg==",
-      "license": "MIT",
       "dependencies": {
         "@wojtekmaj/date-utils": "^1.1.3",
         "clsx": "^2.0.0",

--- a/jefferson-elementary/src/routes/ClassPage.jsx
+++ b/jefferson-elementary/src/routes/ClassPage.jsx
@@ -220,6 +220,9 @@ const ClassPage = () => {
 			gradeAvg: newAvg
 		});
 
+		// Updates grade locally
+		setClassData(prev => ({ ...prev, gradeAvg: newAvg }));
+
 		setStudents(prev =>
 			prev.map(s => s.id === studentId ? { ...s, grade: newGrade } : s)
 		);


### PR DESCRIPTION
Updated the "handleUpdateGrade" function within the ClassPage.jsx file to now include line 224 which automatically updates the average grade locally. Users no longer has to refresh to see the average class grade update after editing the grades of students.